### PR TITLE
Fix URL of blog article

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## The project
 
-This repo is a support for [this article](https://blog.sqreen.io/authentication-best-practices-for-vue/) and a [talk](https://docs.google.com/presentation/d/17e4U-XDMuVXGIj26OXndfAsXOpFjPjjb6QHhTJbBZnI/edit?usp=sharing) given to VueJS Paris meetup
+This repo is a support for [this article](https://blog.sqreen.io/authentication-best-practices-vue/) and a [talk](https://docs.google.com/presentation/d/17e4U-XDMuVXGIj26OXndfAsXOpFjPjjb6QHhTJbBZnI/edit?usp=sharing) given to VueJS Paris meetup
 
 [Demo](https://vue-auth-example.netlify.com) of this repo.
 


### PR DESCRIPTION
The current URL (https://blog.sqreen.io/authentication-best-practices-for-vue/) gives a 404...